### PR TITLE
Exact record support

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -752,10 +752,10 @@ describe('change static type with Constraint', () => {
     | Literal<boolean | number | string>
     | Array<Reflect, false>
     | Array<Reflect, true>
-    | Record<{ [_ in string]: Reflect }, false>
-    | Record<{ [_ in string]: Reflect }, true>
-    | RTPartial<{ [_ in string]: Reflect }, false>
-    | RTPartial<{ [_ in string]: Reflect }, true>
+    | Record<{ [_ in string]: Reflect }, false, false>
+    | Record<{ [_ in string]: Reflect }, true, false>
+    | RTPartial<{ [_ in string]: Reflect }, false, false>
+    | RTPartial<{ [_ in string]: Reflect }, true, false>
     | Tuple2<Reflect, Reflect>
     | Union2<Reflect, Reflect>
     | Intersect2<Reflect, Reflect>

--- a/src/types/record.spec.ts
+++ b/src/types/record.spec.ts
@@ -1,4 +1,4 @@
-import { String, Record, Array } from '..';
+import { String, Record, ExactRecord, Array } from '..';
 
 const AnimalRecord = Record({
   cat: String,
@@ -8,10 +8,10 @@ const AnimalRecord = Record({
 const AnimalNestedRecord = Record({
   cat: String,
   dog: String,
-  zoo: Record({
+  zoo: ExactRecord({
     lion: String,
     penguin: String,
-  }).exact(),
+  }),
 }).exact();
 
 const AnimalsRecord = Array(AnimalRecord);

--- a/src/types/record.spec.ts
+++ b/src/types/record.spec.ts
@@ -1,0 +1,84 @@
+import { String, Record, Array } from '..';
+
+const AnimalRecord = Record({
+  cat: String,
+  dog: String,
+}).exact();
+
+const AnimalNestedRecord = Record({
+  cat: String,
+  dog: String,
+  zoo: Record({
+    lion: String,
+    penguin: String,
+  }).exact(),
+}).exact();
+
+const AnimalsRecord = Array(AnimalRecord);
+
+describe('record', () => {
+  describe('check exact', () => {
+    it('works with same object', () => {
+      AnimalRecord.check({
+        dog: 'Bob2',
+        cat: 'Tiger',
+      });
+    });
+
+    it('throws if additional fields in exact mode', () => {
+      const result = AnimalRecord.validate({
+        dog: 'Bob2',
+        cat: 'Tiger',
+        cow: 'Billy',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.message).toBe('Additional field cow');
+      }
+    });
+
+    it('works with same object nested', () => {
+      AnimalNestedRecord.check({
+        dog: 'Bob',
+        cat: 'Tiger',
+        zoo: {
+          lion: 'a',
+          penguin: 'b',
+        },
+      });
+    });
+
+    it('throws if additional fields in exact mode nested', () => {
+      const result = AnimalNestedRecord.validate({
+        dog: 'Bob',
+        cat: 'Tiger',
+        zoo: {
+          lion: 'a',
+          penguin: 'b',
+          monkey: 'c',
+        },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.message).toBe('Additional field monkey');
+      }
+    });
+
+    it('throws if additional fields in exact mode array', () => {
+      const result = AnimalsRecord.validate([
+        {
+          dog: 'Bob',
+          cat: 'Tiger',
+          cow: 'Brown',
+        },
+      ]);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.message).toBe('Additional field cow');
+      }
+    });
+  });
+});

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -37,6 +37,12 @@ export type Record<
   EX extends boolean
 > = InternalRecord<O, false, RO, EX>;
 
+export type ExactRecord<
+  O extends { [_: string]: Runtype },
+  RO extends boolean,
+  EX extends boolean
+> = InternalRecord<O, false, RO, EX>;
+
 export type Partial<
   O extends { [_: string]: Runtype },
   RO extends boolean,


### PR DESCRIPTION
Added `.exact()` for `Record`. It allows to check that incoming object doesn't have additional fields.

Close #41 

First I tried to create `{ strict: true }`, but `validate`, `check` etc. are shared between multiple Runtypes and they don't really need that setting.