### PR TITLE
Feature: add generic `properties` accessor for complex runtypes

### DIFF
--- a/src/properties.spec.ts
+++ b/src/properties.spec.ts
@@ -1,0 +1,94 @@
+import {
+  Array,
+  String,
+  Record,
+  Number,
+  Tuple,
+  Boolean,
+  Dictionary,
+  Never,
+  Union,
+  Intersect,
+  Literal,
+  Optional,
+} from '.';
+import { Static } from './runtype';
+
+describe('properties', () => {
+  it('should work with array', () => {
+    const R = Array(String);
+    expect(R.properties[global.Number.MIN_VALUE]).toBe(Never);
+    expect(R.properties[global.Number.MIN_SAFE_INTEGER]).toBe(Never);
+    expect(R.properties[-1]).toBe(Never);
+    expect(R.properties[0]).toBe(String);
+    expect(R.properties[1]).toBe(String);
+    expect(R.properties[global.Number.MAX_SAFE_INTEGER]).toBe(String);
+    expect(R.properties[global.Number.MAX_VALUE]).toBe(Never);
+    expect((R.properties as any)['foo']).toBe(Never);
+  });
+  it('should work with record', () => {
+    const R = Record({ foo: String, bar: Number });
+    expect(R.properties.foo).toBe(String);
+    expect(R.properties.bar).toBe(Number);
+    expect((R.properties as any).baz).toBe(Never);
+  });
+  it('should work with tuple', () => {
+    const R = Tuple(String, Number, Boolean);
+    expect(R.properties[0]).toBe(String);
+    expect(R.properties[1]).toBe(Number);
+    expect(R.properties[2]).toBe(Boolean);
+    expect((R.properties as any)[3]).toBe(Never);
+  });
+  it('should work with dictionary', () => {
+    const R = Dictionary(String, Number);
+    expect(R.properties[0]).toBe(String);
+    expect((R.properties as any)['1']).toBe(String);
+    expect(R.properties[0x02]).toBe(String);
+    expect((R.properties as any)['0x03']).toBe(Never);
+    expect((R.properties as any)['foo']).toBe(Never);
+  });
+  it('should work with union', () => {
+    const R = Union(
+      Record({ foo: String, bar: Optional(Boolean) }),
+      Record({ foo: Number, bar: Boolean, baz: String }),
+    );
+    const { foo, bar } = R.properties;
+    expect(foo.tag).toBe('union');
+    expect(bar.tag).toBe('union');
+    expect(foo.alternatives.length).toBe(2);
+    expect(bar.alternatives.length).toBe(2);
+    expect(foo.guard(42)).toBe(true);
+    expect(foo.guard('42')).toBe(true);
+    expect(foo.guard(true)).toBe(false);
+    expect(bar.guard(undefined)).toBe(true);
+    expect(bar.guard(true)).toBe(true);
+    expect(bar.guard('true')).toBe(false);
+    expect((R.properties as any).baz).toBe(Never);
+  });
+  it('should work with intersection', () => {
+    const R = Intersect(Record({ foo: String }), Record({ foo: Literal('test'), bar: String }));
+    const { foo, bar } = R.properties;
+    expect(foo.tag).toBe('intersect');
+    expect(foo.intersectees.length).toBe(2);
+    expect(foo.guard('test')).toBe(true);
+    expect(foo.guard('crap')).toBe(false);
+    expect(foo.guard(42)).toBe(false);
+    expect(bar.tag).toBe('string');
+    expect((R.properties as any).baz.tag).toBe('never');
+  });
+  it('should work with mixed union', () => {
+    const R = Union(String, Record({ foo: String, bar: Optional(Boolean) }));
+    expect((R.properties as any).foo.tag).toBe('never');
+    expect((R.properties as any).bar.tag).toBe('never');
+  });
+  it('should work with mixed intersection', () => {
+    const R = Intersect(String, Record({ foo: String, bar: Optional(Boolean) }));
+    type R = Static<typeof R>;
+    expect(R.properties.foo.tag).toBe('string');
+    expect(R.properties.bar.tag).toBe('optional');
+    const foo: R['foo'] = 'some string';
+    const bar: R['bar'] = true;
+    expect(R.properties.foo.guard(foo)).toBe(true);
+    expect(R.properties.bar.guard(bar)).toBe(true);
+  });
+});

--- a/src/properties.spec.ts
+++ b/src/properties.spec.ts
@@ -24,28 +24,34 @@ describe('properties', () => {
     expect(R.properties[1]).toBe(String);
     expect(R.properties[global.Number.MAX_SAFE_INTEGER]).toBe(String);
     expect(R.properties[global.Number.MAX_VALUE]).toBe(Never);
-    expect((R.properties as any)['foo']).toBe(Never);
+    // @ts-expect-error
+    expect(R.properties['foo']).toBe(Never);
   });
   it('should work with record', () => {
     const R = Record({ foo: String, bar: Number });
     expect(R.properties.foo).toBe(String);
     expect(R.properties.bar).toBe(Number);
-    expect((R.properties as any).baz).toBe(Never);
+    // @ts-expect-error
+    expect(R.properties.baz).toBe(Never);
   });
   it('should work with tuple', () => {
     const R = Tuple(String, Number, Boolean);
     expect(R.properties[0]).toBe(String);
     expect(R.properties[1]).toBe(Number);
     expect(R.properties[2]).toBe(Boolean);
-    expect((R.properties as any)[3]).toBe(Never);
+    // @ts-expect-error
+    expect(R.properties[3]).toBe(Never);
   });
   it('should work with dictionary', () => {
     const R = Dictionary(String, Number);
     expect(R.properties[0]).toBe(String);
-    expect((R.properties as any)['1']).toBe(String);
+    // @ts-expect-error
+    expect(R.properties['1']).toBe(String);
     expect(R.properties[0x02]).toBe(String);
-    expect((R.properties as any)['0x03']).toBe(Never);
-    expect((R.properties as any)['foo']).toBe(Never);
+    // @ts-expect-error
+    expect(R.properties['0x03']).toBe(Never);
+    // @ts-expect-error
+    expect(R.properties['foo']).toBe(Never);
   });
   it('should work with union', () => {
     const R = Union(
@@ -63,7 +69,8 @@ describe('properties', () => {
     expect(bar.guard(undefined)).toBe(true);
     expect(bar.guard(true)).toBe(true);
     expect(bar.guard('true')).toBe(false);
-    expect((R.properties as any).baz).toBe(Never);
+    // @ts-expect-error
+    expect(R.properties.baz).toBe(Never);
   });
   it('should work with intersection', () => {
     const R = Intersect(Record({ foo: String }), Record({ foo: Literal('test'), bar: String }));
@@ -74,12 +81,15 @@ describe('properties', () => {
     expect(foo.guard('crap')).toBe(false);
     expect(foo.guard(42)).toBe(false);
     expect(bar.tag).toBe('string');
-    expect((R.properties as any).baz.tag).toBe('never');
+    // @ts-expect-error
+    expect(R.properties.baz.tag).toBe('never');
   });
   it('should work with mixed union', () => {
     const R = Union(String, Record({ foo: String, bar: Optional(Boolean) }));
-    expect((R.properties as any).foo.tag).toBe('never');
-    expect((R.properties as any).bar.tag).toBe('never');
+    // @ts-expect-error
+    expect(R.properties.foo.tag).toBe('never');
+    // @ts-expect-error
+    expect(R.properties.bar.tag).toBe('never');
   });
   it('should work with mixed intersection', () => {
     const R = Intersect(String, Record({ foo: String, bar: Optional(Boolean) }));

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -15,17 +15,28 @@ export type Reflect =
   | ({ tag: 'symbol'; (key: string | undefined): Runtype<symbol> } & Runtype<symbol>)
   | ({ tag: 'literal'; value: LiteralBase } & Runtype<LiteralBase>)
   | ({ tag: 'template'; strings: string[]; runtypes: Runtype<LiteralBase>[] } & Runtype<string>)
-  | ({ tag: 'array'; element: Reflect; isReadonly: boolean } & Runtype<ReadonlyArray<unknown>>)
+  | ({
+      tag: 'array';
+      element: Reflect;
+      isReadonly: boolean;
+      readonly properties: { [_: number]: Reflect };
+    } & Runtype<ReadonlyArray<unknown>>)
   | ({
       tag: 'record';
       fields: { [_: string]: Reflect };
       isPartial: boolean;
       isReadonly: boolean;
+      readonly properties: { [_: string]: Reflect };
     } & Runtype<{ readonly [_ in string]: unknown }>)
-  | ({ tag: 'dictionary'; key: 'string' | 'number' | 'symbol'; value: Reflect } & Runtype<{
+  | ({
+      tag: 'dictionary';
+      key: 'string' | 'number' | 'symbol';
+      value: Reflect;
+      readonly properties: { [_ in string | number | symbol]: Reflect };
+    } & Runtype<{
       [_: string]: unknown;
     }>)
-  | ({ tag: 'tuple'; components: Reflect[] } & Runtype<unknown[]>)
+  | ({ tag: 'tuple'; components: Reflect[]; readonly properties: Reflect[] } & Runtype<unknown[]>)
   | ({ tag: 'union'; alternatives: Reflect[] } & Runtype)
   | ({ tag: 'intersect'; intersectees: Reflect[] } & Runtype)
   | ({ tag: 'optional'; underlying: Reflect } & Runtype)

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -16,7 +16,7 @@ interface Arr<E extends RuntypeBase, RO extends boolean = boolean>
 
   asReadonly(): Arr<E, true>;
 
-  readonly properties: { [_: number]: E };
+  properties: { readonly [_: number]: E };
 }
 
 /**

--- a/src/types/dictionary.ts
+++ b/src/types/dictionary.ts
@@ -26,7 +26,7 @@ export interface Dictionary<V extends RuntypeBase, K extends DictionaryKeyType>
   key: StringLiteralFor<K>;
   value: V;
 
-  readonly properties: { [_ in K]: V };
+  properties: { readonly [_ in K]: V };
 }
 
 export interface StringDictionary<V extends RuntypeBase>
@@ -37,7 +37,7 @@ export interface StringDictionary<V extends RuntypeBase>
   key: 'string';
   value: V;
 
-  readonly properties: { [_: string]: V };
+  properties: { readonly [_: string]: V };
 }
 
 export interface NumberDictionary<V extends RuntypeBase>
@@ -48,7 +48,7 @@ export interface NumberDictionary<V extends RuntypeBase>
   key: 'number';
   value: V;
 
-  readonly properties: { [_: number]: V };
+  properties: { readonly [_: number]: V };
 }
 
 /**

--- a/src/types/intersect.ts
+++ b/src/types/intersect.ts
@@ -16,7 +16,7 @@ export interface Intersect<A extends readonly [RuntypeBase, ...RuntypeBase[]]>
   tag: 'intersect';
   intersectees: A;
 
-  readonly properties: {
+  properties: {
     [K in keyof A]: A[K] extends { properties: unknown } ? A[K] : never;
   }[number] extends never
     ? {}
@@ -26,7 +26,7 @@ export interface Intersect<A extends readonly [RuntypeBase, ...RuntypeBase[]]>
     ? UnionToIntersection<U> extends infer I
       ? Merge<{ [K in keyof I]: I[K] extends never ? unknown : I[K] } & U> extends infer M
         ? {
-            [K in keyof M]: UnionToTuple<M[K]> extends infer T
+            readonly [K in keyof M]: UnionToTuple<M[K]> extends infer T
               ? T extends [RuntypeBase, ...RuntypeBase[]]
                 ? T extends [RuntypeBase, RuntypeBase, ...RuntypeBase[]]
                   ? Intersect<T>

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -74,7 +74,7 @@ export interface InternalRecord<
     RO
   >;
 
-  readonly properties: O;
+  properties: { readonly [K in keyof O]: O[K] };
 }
 
 export type Record<

--- a/src/types/tuple.ts
+++ b/src/types/tuple.ts
@@ -2,6 +2,7 @@ import { Reflect } from '../reflect';
 import { Details, Result } from '../result';
 import { Runtype, RuntypeBase, Static, create, innerValidate } from '../runtype';
 import { enumerableKeysOf, FAILURE, SUCCESS } from '../util';
+import { Never } from './never';
 
 export interface Tuple<A extends readonly RuntypeBase[]>
   extends Runtype<
@@ -11,13 +12,18 @@ export interface Tuple<A extends readonly RuntypeBase[]>
   > {
   tag: 'tuple';
   components: A;
+
+  readonly properties: A;
 }
 
 /**
  * Construct a tuple runtype from runtypes for each of its elements.
  */
 export function Tuple<T extends readonly RuntypeBase[]>(...components: T): Tuple<T> {
-  const self = ({ tag: 'tuple', components } as unknown) as Reflect;
+  const properties = new Proxy(components, {
+    get: (components, key) => components[key as any] || Never,
+  });
+  const self = ({ tag: 'tuple', components, properties } as unknown) as Reflect;
   return create<any>((xs, visited) => {
     if (!Array.isArray(xs)) return FAILURE.TYPE_INCORRECT(self, xs);
 

--- a/src/types/tuple.ts
+++ b/src/types/tuple.ts
@@ -13,7 +13,7 @@ export interface Tuple<A extends readonly RuntypeBase[]>
   tag: 'tuple';
   components: A;
 
-  readonly properties: A;
+  properties: { readonly [K in keyof A]: A[K] };
 }
 
 /**

--- a/src/types/union.spec.ts
+++ b/src/types/union.spec.ts
@@ -1,6 +1,7 @@
 import { Union, String, Literal, Record, Number, InstanceOf } from '..';
 import { Failcode } from '../result';
 import { Static } from '../runtype';
+// import { Boolean } from './boolean';
 import { LiteralBase } from './literal';
 
 const ThreeOrString = Union(Literal(3), String);
@@ -69,6 +70,8 @@ describe('union', () => {
         message: 'Expected { kind: "circle"; radius: number; }, but was incompatible',
         details: { radius: 'Expected number, but was missing' },
       });
+
+      // console.log(Union(String, Number, Record({ test: Boolean })).validate({ test: new Date() }));
 
       expect(Shape.validate({ kind: 'other', size: new Date() })).not.toHaveProperty('key');
     });

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -14,7 +14,7 @@ export interface Union<A extends readonly [RuntypeBase, ...RuntypeBase[]]>
   alternatives: A;
   match: Match<A>;
 
-  readonly properties: {
+  properties: {
     [K in keyof A]: A[K] extends { properties: unknown } ? never : A[K];
   }[number] extends never
     ? Merge<
@@ -23,7 +23,7 @@ export interface Union<A extends readonly [RuntypeBase, ...RuntypeBase[]]>
         }[number]['properties']
       > extends infer M
       ? {
-          [K in keyof M]: UnionToTuple<M[K]> extends infer T
+          readonly [K in keyof M]: UnionToTuple<M[K]> extends infer T
             ? T extends [RuntypeBase, ...RuntypeBase[]]
               ? T extends [RuntypeBase, RuntypeBase, ...RuntypeBase[]]
                 ? Union<T>

--- a/src/util.ts
+++ b/src/util.ts
@@ -90,3 +90,23 @@ export const FAILURE = Object.assign(
     },
   },
 );
+
+export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I,
+) => void
+  ? I
+  : never;
+export type LastOf<T> = UnionToIntersection<T extends any ? () => T : never> extends () => infer R
+  ? R
+  : never;
+export type Push<T extends any[], V> = [...T, V];
+export type UnionToTuple<T, L = LastOf<T>, N = [T] extends [never] ? true : false> = true extends N
+  ? []
+  : Push<UnionToTuple<Exclude<T, L>>, L>;
+
+export type TupleToUnion<T extends unknown[]> = T[number];
+export type TupleToIntersection<T extends unknown[]> = UnionToIntersection<TupleToUnion<T>>;
+
+export type Merge<T> = Pick<T, keyof T>;
+
+export const isNumberLikeString = (string: string) => /^(?:0|[1-9][0-9]*)$/u.test(string);


### PR DESCRIPTION
Closes #217. ~~This is still a very draft, but it would work. Test cases are not yet sufficient almost certainly.~~