### PR TITLE
Feature/improved failure handling experience

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -77,7 +77,7 @@ export type Failure = {
   details?: Details;
 
   /**
-   * The same as `details`, but with received value
+   * The same as `details`, but with more detailed error explanation
    */
   extraDetails?: Details;
 };

--- a/src/result.ts
+++ b/src/result.ts
@@ -67,9 +67,19 @@ export type Failure = {
   message: string;
 
   /**
+   * Received value
+   */
+  received: any;
+
+  /**
    * A detailed object enumerating where the validation failed exactly.
    */
   details?: Details;
+
+  /**
+   * The same as `details`, but with received value
+   */
+  extraDetails?: Details;
 };
 
 /**

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -147,7 +147,7 @@ export function create<A extends RuntypeBase>(
   A.withGuard = withGuard;
   A.withBrand = withBrand;
   A.reflect = A;
-  A.toString = () => `Runtype<${show(A)}>`;
+  A.toString = () => `Runtype<${show(A, true)}>`;
 
   return A;
 

--- a/src/show.spec.ts
+++ b/src/show.spec.ts
@@ -150,7 +150,7 @@ const cases: [Reflect, string][] = [
 ];
 
 for (const [T, expected] of cases) {
-  const s = show(T);
+  const s = show(T, false);
   it(s, () => {
     expect(s).toBe(expected);
     expect(T.toString()).toBe(`Runtype<${s}>`);

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -40,7 +40,22 @@ function InternalArr<E extends RuntypeBase, RO extends boolean>(
         [],
       );
 
-      if (enumerableKeysOf(details).length !== 0) return FAILURE.CONTENT_INCORRECT(self, details);
+      const extraDetails = keys.reduce<{ [key: number]: string | Details } & (string | Details)[]>(
+        (details, key) => {
+          const result = results[key as any];
+          if (!result.success)
+            details[key as any] = result.extraDetails
+              ? result.extraDetails
+              : {
+                  message: result.message,
+                  received: result.received,
+                };
+          return details;
+        },
+        [],
+      );
+      if (enumerableKeysOf(details).length !== 0)
+        return FAILURE.CONTENT_INCORRECT(self, details, extraDetails);
       else return SUCCESS(xs);
     }, self),
   );

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -49,6 +49,7 @@ function InternalArr<E extends RuntypeBase, RO extends boolean>(
               : {
                   message: result.message,
                   received: result.received,
+                  code: result.code,
                 };
           return details;
         },

--- a/src/types/dictionary.ts
+++ b/src/types/dictionary.ts
@@ -138,6 +138,7 @@ export function Dictionary<
             : {
                 message: result.message,
                 received: result.received,
+                code: result.code,
               };
         return details;
       },

--- a/src/types/dictionary.ts
+++ b/src/types/dictionary.ts
@@ -90,7 +90,7 @@ export function Dictionary<
       : key === 'number'
       ? NumberKey
       : (key as Exclude<K, string>);
-  const keyString = show(keyRuntype as any);
+  const keyString = show(keyRuntype as any, true);
   const self = { tag: 'dictionary', key: keyString, value } as any;
   return create<any>((x, visited) => {
     if (x === null || x === undefined || typeof x !== 'object')

--- a/src/types/dictionary.ts
+++ b/src/types/dictionary.ts
@@ -129,8 +129,23 @@ export function Dictionary<
       },
       {},
     );
+    const extraDetails = keys.reduce<{ [key in string | number | symbol]: string | Details }>(
+      (details, key) => {
+        const result = results[key as any];
+        if (!result.success)
+          details[key as any] = result.extraDetails
+            ? result.extraDetails
+            : {
+                message: result.message,
+                received: result.received,
+              };
+        return details;
+      },
+      {},
+    );
 
-    if (enumerableKeysOf(details).length !== 0) return FAILURE.CONTENT_INCORRECT(self, details);
+    if (enumerableKeysOf(details).length !== 0)
+      return FAILURE.CONTENT_INCORRECT(self, details, extraDetails);
     else return SUCCESS(x);
   }, self);
 }

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -153,6 +153,7 @@ export function InternalRecord<
               : {
                   message: result.message,
                   received: result.received,
+                  code: result.code,
                 };
 
           return details;

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -144,7 +144,24 @@ export function InternalRecord<
         {},
       );
 
-      if (enumerableKeysOf(details).length !== 0) return FAILURE.CONTENT_INCORRECT(self, details);
+      const extraDetails = keys.reduce<{ [key in string | number | symbol]: string | Details }>(
+        (details, key) => {
+          const result = results[key as any];
+          if (!result.success)
+            details[key as any] = result.extraDetails
+              ? result.extraDetails
+              : {
+                  message: result.message,
+                  received: result.received,
+                };
+
+          return details;
+        },
+        {},
+      );
+
+      if (enumerableKeysOf(details).length !== 0)
+        return FAILURE.CONTENT_INCORRECT(self, details, extraDetails);
       else return SUCCESS(x);
     }, self),
   );

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -428,7 +428,7 @@ export function Template<
       }
       return SUCCESS(value);
     } else {
-      return FAILURE.VALUE_INCORRECT('string', `${show(self)}`, `"${literal(value)}"`);
+      return FAILURE.VALUE_INCORRECT('string', `${show(self, true)}`, `"${literal(value)}"`);
     }
   };
 
@@ -447,7 +447,7 @@ export function Template<
     else {
       const validated = test(value, visited);
       if (!validated.success) {
-        const result = FAILURE.VALUE_INCORRECT('string', `${show(self)}`, `"${value}"`);
+        const result = FAILURE.VALUE_INCORRECT('string', `${show(self, true)}`, `"${value}"`);
         if (result.message !== validated.message)
           // TODO: Should use `details` here, but it needs unionizing `string` anew to the definition of `Details`, which is a breaking change
           result.message += ` (inner: ${validated.message})`;

--- a/src/types/tuple.ts
+++ b/src/types/tuple.ts
@@ -48,6 +48,7 @@ export function Tuple<T extends readonly RuntypeBase[]>(...components: T): Tuple
             : {
                 message: result.message,
                 received: result.received,
+                code: result.code,
               };
         return details;
       },

--- a/src/types/tuple.ts
+++ b/src/types/tuple.ts
@@ -39,8 +39,23 @@ export function Tuple<T extends readonly RuntypeBase[]>(...components: T): Tuple
       },
       [],
     );
+    const extraDetails = keys.reduce<{ [key: number]: string | Details } & (string | Details)[]>(
+      (details, key) => {
+        const result = results[key as any];
+        if (!result.success)
+          details[key as any] = result.extraDetails
+            ? result.extraDetails
+            : {
+                message: result.message,
+                received: result.received,
+              };
+        return details;
+      },
+      [],
+    );
 
-    if (enumerableKeysOf(details).length !== 0) return FAILURE.CONTENT_INCORRECT(self, details);
+    if (enumerableKeysOf(details).length !== 0)
+      return FAILURE.CONTENT_INCORRECT(self, details, extraDetails);
     else return SUCCESS(xs);
   }, self);
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -43,7 +43,7 @@ export const FAILURE = Object.assign(
   {
     TYPE_INCORRECT: (self: Reflect, value: unknown) => {
       const message = `Expected ${
-        self.tag === 'template' ? `string ${show(self)}` : show(self)
+        self.tag === 'template' ? `string ${show(self, true)}` : show(self, false)
       }, but was ${typeOf(value)}`;
       return FAILURE(Failcode.TYPE_INCORRECT, message);
     },
@@ -56,12 +56,15 @@ export const FAILURE = Object.assign(
     KEY_INCORRECT: (self: Reflect, expected: Reflect, value: unknown) => {
       return FAILURE(
         Failcode.KEY_INCORRECT,
-        `Expected ${show(self)} key to be ${show(expected)}, but was ${typeOf(value)}`,
+        `Expected ${show(self, true)} key to be ${show(expected, true)}, but was ${typeOf(value)}`,
       );
     },
     CONTENT_INCORRECT: (self: Reflect, details: Details) => {
       const formattedDetails = JSON.stringify(details, null, 2).replace(/^ *null,\n/gm, '');
-      const message = `Validation failed:\n${formattedDetails}.\nObject should match ${show(self)}`;
+      const message = `Validation failed:\n${formattedDetails}.\nObject should match ${show(
+        self,
+        true,
+      )}`;
       return FAILURE(Failcode.CONTENT_INCORRECT, message, details);
     },
     ARGUMENT_INCORRECT: (message: string) => {
@@ -74,11 +77,11 @@ export const FAILURE = Object.assign(
       const info = message ? `: ${message}` : '';
       return FAILURE(
         Failcode.CONSTRAINT_FAILED,
-        `Failed constraint check for ${show(self)}${info}`,
+        `Failed constraint check for ${show(self, true)}${info}`,
       );
     },
     PROPERTY_MISSING: (self: Reflect) => {
-      const message = `Expected ${show(self)}, but was missing`;
+      const message = `Expected ${show(self, false)}, but was missing`;
       return FAILURE(Failcode.PROPERTY_MISSING, message);
     },
     PROPERTY_PRESENT: (value: unknown) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -34,63 +34,67 @@ export function SUCCESS<T extends unknown>(value: T): Success<T> {
 }
 
 export const FAILURE = Object.assign(
-  (code: Failcode, message: string, details?: Details): Failure => ({
+  (
+    code: Failcode,
+    message: string,
+    received: any,
+    details?: Details,
+    extraDetails?: Details,
+  ): Failure => ({
     success: false,
     code,
     message,
+    received,
     ...(details ? { details } : {}),
+    ...(extraDetails ? { extraDetails } : {}),
   }),
   {
     TYPE_INCORRECT: (self: Reflect, value: unknown) => {
       const message = `Expected ${
         self.tag === 'template' ? `string ${show(self, true)}` : show(self, false)
       }, but was ${typeOf(value)}`;
-      return FAILURE(Failcode.TYPE_INCORRECT, message);
+      return FAILURE(Failcode.TYPE_INCORRECT, message, value);
     },
     VALUE_INCORRECT: (name: string, expected: unknown, received: unknown) => {
-      return FAILURE(
-        Failcode.VALUE_INCORRECT,
-        `Expected ${name} ${String(expected)}, but was ${String(received)}`,
-      );
+      const msg = `Expected ${name} ${String(expected)}, but was ${String(received)}`;
+      return FAILURE(Failcode.VALUE_INCORRECT, msg, msg);
     },
     KEY_INCORRECT: (self: Reflect, expected: Reflect, value: unknown) => {
-      return FAILURE(
-        Failcode.KEY_INCORRECT,
-        `Expected ${show(self, true)} key to be ${show(expected, true)}, but was ${typeOf(value)}`,
-      );
+      const msg = `Expected ${show(self, true)} key to be ${show(expected, true)}, but was ${typeOf(
+        value,
+      )}`;
+      return FAILURE(Failcode.KEY_INCORRECT, msg, msg);
     },
-    CONTENT_INCORRECT: (self: Reflect, details: Details) => {
+    CONTENT_INCORRECT: (self: Reflect, details: Details, extraDetails: Details) => {
       const formattedDetails = JSON.stringify(details, null, 2).replace(/^ *null,\n/gm, '');
       const message = `Validation failed:\n${formattedDetails}.\nObject should match ${show(
         self,
         true,
       )}`;
-      return FAILURE(Failcode.CONTENT_INCORRECT, message, details);
+      return FAILURE(Failcode.CONTENT_INCORRECT, message, '', details, extraDetails);
     },
     ARGUMENT_INCORRECT: (message: string) => {
-      return FAILURE(Failcode.ARGUMENT_INCORRECT, message);
+      return FAILURE(Failcode.ARGUMENT_INCORRECT, message, message);
     },
     RETURN_INCORRECT: (message: string) => {
-      return FAILURE(Failcode.RETURN_INCORRECT, message);
+      return FAILURE(Failcode.RETURN_INCORRECT, message, message);
     },
     CONSTRAINT_FAILED: (self: Reflect, message?: string) => {
       const info = message ? `: ${message}` : '';
-      return FAILURE(
-        Failcode.CONSTRAINT_FAILED,
-        `Failed constraint check for ${show(self, true)}${info}`,
-      );
+      const msg = `Failed constraint check for ${show(self, true)}${info}`;
+      return FAILURE(Failcode.CONSTRAINT_FAILED, msg, msg);
     },
     PROPERTY_MISSING: (self: Reflect) => {
       const message = `Expected ${show(self, false)}, but was missing`;
-      return FAILURE(Failcode.PROPERTY_MISSING, message);
+      return FAILURE(Failcode.PROPERTY_MISSING, message, undefined);
     },
     PROPERTY_PRESENT: (value: unknown) => {
       const message = `Expected nothing, but was ${typeOf(value)}`;
-      return FAILURE(Failcode.PROPERTY_PRESENT, message);
+      return FAILURE(Failcode.PROPERTY_PRESENT, message, message);
     },
     NOTHING_EXPECTED: (value: unknown) => {
       const message = `Expected nothing, but was ${typeOf(value)}`;
-      return FAILURE(Failcode.NOTHING_EXPECTED, message);
+      return FAILURE(Failcode.NOTHING_EXPECTED, message, message);
     },
   },
 );


### PR DESCRIPTION
Hello!

I have 2 ideas (and ready implementations in this PR) to improve error message readability.

## The first idea
I often encounter is overly detailed logging of complex structures in the "Expected" messages.

For example: 
let's have this schema
```
const Obj = Record({
  id: Number,
  name: String,
  nested: Record({
    id2: Number,
    name2: String,
    nested2: Array(
      Record({
        nested3: Record({
          id3: String,
        }),
      }),
    ),
  }),
});

// and we will validate this object
const result = Obj.validate({
		id: 3,
		name: "test" 
})
```
The validation result will be very messy:
```
{
      nested: 'Expected { id2: number; name2: string; nested2: { nested3: { id3: string; }; }[]; }, but was missing'
}
```

It seems unnecessary to describe the expected type since it is already known in the runtypes schema description. Moreover, this description complicates error message readability.

Instead, I propose writing "Expected (array | tuple | object | dictionary) but was ..."

in this PR result will change to this
```
{
      nested: 'Expected object, but was missing'
}
```
It looks readable and doesn't lose its meaning.


## The second idea
In messages like "Expected something but was (array | object)" it would be helpful to see exactly which entity was received.

I have decided to add a new field called `extraDetails` next to the `details` field, which will contain not only the error message but also the actual value (`received` field) and possibly the error code.

Let's go back to the previous schema and pass it this object as input:
```
const result = Obj.validate({
      id: 3,
      name: 5,
      nested: { nested2: { a: 'b' } },
  })
```
In this PR, the `result.extraDetails` field will contain this convenient message:
```
 {
      name: {
        message: 'Expected string, but was number',
        received: 5,
        code: 'TYPE_INCORRECT'
      },
      nested: {
        id2: {
          message: 'Expected number, but was missing',
          received: undefined,
          code: 'PROPERTY_MISSING'
        },
        name2: {
          message: 'Expected string, but was missing',
          received: undefined,
          code: 'PROPERTY_MISSING'
        },
        nested2: {
          message: 'Expected array, but was object',
          received: { a: 'b' },
          code: 'TYPE_INCORRECT'
        }
      }
  }
```
Thus, `extraDetails` will improve error perception without affecting the existing `details` field.