### PR TITLE
feat!: add `withAssertion` helper

### DIFF
--- a/src/Constraint.test.ts
+++ b/src/Constraint.test.ts
@@ -1,8 +1,33 @@
+import Literal from "./Literal.ts"
+import { type Static } from "./Runtype.ts"
 import Unknown from "./Unknown.ts"
 import { assert } from "@std/assert"
 
-Deno.test("Constraint", async () => {
-	const YourRuntype = Unknown.withConstraint(x => x === true)
-	assert(YourRuntype.guard(true))
-	assert(!YourRuntype.guard(false))
+Deno.test("Constraint", async t => {
+	await t.step("withConstraint", async t => {
+		const True = Literal(true)
+		const YourRuntype = Unknown.withConstraint(True.guard)
+		assert(YourRuntype.guard(true))
+		assert(!YourRuntype.guard(false))
+	})
+	await t.step("withGuard", async t => {
+		const True = Literal(true)
+		const YourRuntype = Unknown.withGuard(True.guard)
+		type YourRuntype = Static<typeof YourRuntype>
+		const x: YourRuntype = true
+		// @ts-expect-error: should fail
+		const y: YourRuntype = false
+		assert(YourRuntype.guard(true))
+		assert(!YourRuntype.guard(false))
+	})
+	await t.step("withAssertion", async t => {
+		const True = Literal(true)
+		const YourRuntype = Unknown.withAssertion(True.assert)
+		type YourRuntype = Static<typeof YourRuntype>
+		const x: YourRuntype = true
+		// @ts-expect-error: should fail
+		const y: YourRuntype = false
+		assert(YourRuntype.guard(true))
+		assert(!YourRuntype.guard(false))
+	})
 })

--- a/src/Constraint.ts
+++ b/src/Constraint.ts
@@ -8,23 +8,25 @@ interface Constraint<R extends Runtype.Core = Runtype.Core, U extends Static<R> 
 	extends Runtype.Common<U> {
 	tag: "constraint"
 	underlying: R
-	constraint: <S extends Runtype.Core<Static<R>>>(x: Static<S>) => boolean | string
+	constraint: <S extends Runtype.Core<Static<R>>>(x: Static<S>) => asserts x is U
 }
 
 const Constraint = <R extends Runtype.Core, U extends Static<R>>(
 	underlying: R,
-	constraint: (x: Static<R>) => boolean | string,
+	constraint: (x: Static<R>) => asserts x is U,
 ) =>
 	Runtype.create<Constraint<R, U>>(
 		(value, innerValidate, self) => {
 			const result = underlying.validate(value) as Result<Static<R>>
-
 			if (!result.success) return result
-
-			const message = constraint(result.value)
-			if (typeof message === "string") return FAILURE.CONSTRAINT_FAILED(self, message)
-			else if (!message) return FAILURE.CONSTRAINT_FAILED(self)
-			return SUCCESS(result.value as U)
+			try {
+				constraint(result.value)
+				return SUCCESS(result.value)
+			} catch (error) {
+				if (typeof error === "string") return FAILURE.CONSTRAINT_FAILED(self, error)
+				else if (error instanceof Error) return FAILURE.CONSTRAINT_FAILED(self, error.message)
+				return FAILURE.CONSTRAINT_FAILED(self)
+			}
 		},
 		{ tag: "constraint", underlying, constraint },
 	)

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,6 @@
 import Array from "./Array.ts"
 import BigInt from "./BigInt.ts"
 import Boolean from "./Boolean.ts"
-import Constraint from "./Constraint.ts"
 import Function from "./Function.ts"
 import InstanceOf from "./InstanceOf.ts"
 import Intersect from "./Intersect.ts"
@@ -124,7 +123,7 @@ const runtypes = {
 	template3b: Template`${Literal("4")}${Literal("2")}`,
 	template3c: Template("4", "2"),
 	template3d: Template`42`,
-	template4: Template`Must be ${Constraint(String, s => s === s.toLowerCase())}`,
+	template4: Template`Must be ${String.withConstraint(s => s === s.toLowerCase())}`,
 	Sym,
 	SymForRuntypes: Sym("runtypes"),
 	symbolArray: Array(Sym),


### PR DESCRIPTION
Breaking change because `Constraint` constructor now requires an assertion function instead of traditional `x => boolean | string` as input.