### PR TITLE
Fix Literal TypeError on null prototype objects

### DIFF
--- a/src/Literal.test.ts
+++ b/src/Literal.test.ts
@@ -47,7 +47,7 @@ Deno.test("Literal", async t => {
 		assertObjectMatch(Literal(null).validate(value), {
 			success: false,
 			code: "VALUE_INCORRECT",
-			message: "Expected literal `null`, but was `[object Object],[object Object]`",
+			message: "Expected literal `null`, but was `[object Object]`",
 		})
 	})
 	await t.step("invalidates symbol", async t => {
@@ -61,7 +61,7 @@ Deno.test("Literal", async t => {
 		assertObjectMatch(Literal(null).validate([Symbol("example"), Symbol()]), {
 			success: false,
 			code: "VALUE_INCORRECT",
-			message: "Expected literal `null`, but was `Symbol(example),Symbol()`",
+			message: "Expected literal `null`, but was `[object Object]`",
 		})
 	})
 })

--- a/src/Literal.test.ts
+++ b/src/Literal.test.ts
@@ -1,0 +1,70 @@
+import Literal from "./Literal.js"
+import { assert,assertObjectMatch } from "@std/assert"
+
+Deno.test("Literal", async t => {
+	await t.step("validates `BigInt(0)`", async t => {
+		assert(Literal(BigInt(0)).guard(BigInt(0)))
+	})
+	await t.step("validates `42`", async t => {
+		assert(Literal(42).guard(42))
+	})
+	await t.step("validates `false`", async t => {
+		assert(Literal(false).guard(false))
+	})
+	await t.step("validates `null`", async t => {
+		assert(Literal(null).guard(null))
+	})
+	await t.step("validates `undefined`", async t => {
+		assert(Literal(undefined).guard(undefined))
+	})
+	await t.step('validates `"Hello, World!"`', async t => {
+		assert(Literal("Hello, World!").guard("Hello, World!"))
+	})
+	await t.step("invalidates `NaN` because JavaScript", async t => {
+		assertObjectMatch(Literal(NaN).validate(NaN), {
+			success: false,
+			code: "VALUE_INCORRECT",
+			message: 'Expected literal `NaN`, but was `NaN`',
+		})
+	})
+	await t.step("invalidates object", async t => {
+		assertObjectMatch(Literal(null).validate({ key: "value" }), {
+			success: false,
+			code: "VALUE_INCORRECT",
+			message: 'Expected literal `null`, but was `[object Object]`',
+		})
+	})
+	await t.step("invalidates null prototype object", async t => {
+		assertObjectMatch(Literal(null).validate(Object.create(null)), {
+			success: false,
+			code: "VALUE_INCORRECT",
+			message: 'Expected literal `null`, but was `[object null]`',
+		})
+	})
+	await t.step("invalidates null prototype objects", async t => {
+		const value = [
+			Object.assign(Object.create(null), { key: "value "}),
+			Object.create(null),
+		]
+
+		assertObjectMatch(Literal(null).validate(value), {
+			success: false,
+			code: "VALUE_INCORRECT",
+			message: 'Expected literal `null`, but was `[object null],[object null]`',
+		})
+	})
+	await t.step("invalidates symbol", async t => {
+		assertObjectMatch(Literal(null).validate(Symbol()), {
+			success: false,
+			code: "VALUE_INCORRECT",
+			message: 'Expected literal `null`, but was `Symbol()`',
+		})
+	})
+	await t.step("invalidates symbols", async t => {
+		assertObjectMatch(Literal(null).validate([Symbol("example"), Symbol()]), {
+			success: false,
+			code: "VALUE_INCORRECT",
+			message: 'Expected literal `null`, but was `Symbol(example),Symbol()`',
+		})
+	})
+})

--- a/src/Literal.test.ts
+++ b/src/Literal.test.ts
@@ -1,5 +1,5 @@
 import Literal from "./Literal.js"
-import { assert,assertObjectMatch } from "@std/assert"
+import { assert, assertObjectMatch } from "@std/assert"
 
 Deno.test("Literal", async t => {
 	await t.step("validates `BigInt(0)`", async t => {
@@ -24,47 +24,44 @@ Deno.test("Literal", async t => {
 		assertObjectMatch(Literal(NaN).validate(NaN), {
 			success: false,
 			code: "VALUE_INCORRECT",
-			message: 'Expected literal `NaN`, but was `NaN`',
+			message: "Expected literal `NaN`, but was `NaN`",
 		})
 	})
 	await t.step("invalidates object", async t => {
 		assertObjectMatch(Literal(null).validate({ key: "value" }), {
 			success: false,
 			code: "VALUE_INCORRECT",
-			message: 'Expected literal `null`, but was `[object Object]`',
+			message: "Expected literal `null`, but was `[object Object]`",
 		})
 	})
 	await t.step("invalidates null prototype object", async t => {
 		assertObjectMatch(Literal(null).validate(Object.create(null)), {
 			success: false,
 			code: "VALUE_INCORRECT",
-			message: 'Expected literal `null`, but was `[object null]`',
+			message: "Expected literal `null`, but was `[object Object]`",
 		})
 	})
 	await t.step("invalidates null prototype objects", async t => {
-		const value = [
-			Object.assign(Object.create(null), { key: "value "}),
-			Object.create(null),
-		]
+		const value = [Object.assign(Object.create(null), { key: "value " }), Object.create(null)]
 
 		assertObjectMatch(Literal(null).validate(value), {
 			success: false,
 			code: "VALUE_INCORRECT",
-			message: 'Expected literal `null`, but was `[object null],[object null]`',
+			message: "Expected literal `null`, but was `[object Object],[object Object]`",
 		})
 	})
 	await t.step("invalidates symbol", async t => {
 		assertObjectMatch(Literal(null).validate(Symbol()), {
 			success: false,
 			code: "VALUE_INCORRECT",
-			message: 'Expected literal `null`, but was `Symbol()`',
+			message: "Expected literal `null`, but was `Symbol()`",
 		})
 	})
 	await t.step("invalidates symbols", async t => {
 		assertObjectMatch(Literal(null).validate([Symbol("example"), Symbol()]), {
 			success: false,
 			code: "VALUE_INCORRECT",
-			message: 'Expected literal `null`, but was `Symbol(example),Symbol()`',
+			message: "Expected literal `null`, but was `Symbol(example),Symbol()`",
 		})
 	})
 })

--- a/src/Literal.test.ts
+++ b/src/Literal.test.ts
@@ -1,4 +1,4 @@
-import Literal from "./Literal.js"
+import Literal from "./Literal.ts"
 import { assert, assertObjectMatch } from "@std/assert"
 
 Deno.test("Literal", async t => {

--- a/src/Literal.ts
+++ b/src/Literal.ts
@@ -16,8 +16,8 @@ interface Literal<T extends LiteralBase = LiteralBase> extends Runtype.Common<T>
 const literal = (value: unknown): string =>
 	Array.isArray(value)
 		? globalThis.String(value.map(literal))
-		: value !== null && typeof value === 'object' && Object.getPrototypeOf(value) === null
-			? '[object null]'
+		: value !== null && typeof value === "object"
+			? "[object Object]"
 			: typeof value === "bigint"
 				? globalThis.String(value) + "n"
 				: globalThis.String(value)

--- a/src/Literal.ts
+++ b/src/Literal.ts
@@ -13,15 +13,14 @@ interface Literal<T extends LiteralBase = LiteralBase> extends Runtype.Common<T>
 	value: T
 }
 
-/**
- * Be aware of an Array of Symbols `[Symbol()]` which would throw "TypeError: Cannot convert a Symbol value to a string"
- */
-const literal = (value: unknown) =>
+const literal = (value: unknown): string =>
 	Array.isArray(value)
-		? globalThis.String(value.map(globalThis.String))
-		: typeof value === "bigint"
-			? globalThis.String(value) + "n"
-			: globalThis.String(value)
+		? globalThis.String(value.map(literal))
+		: value !== null && typeof value === 'object' && Object.getPrototypeOf(value) === null
+			? '[object null]'
+			: typeof value === "bigint"
+				? globalThis.String(value) + "n"
+				: globalThis.String(value)
 
 /**
  * Construct a runtype for a type literal.

--- a/src/Literal.ts
+++ b/src/Literal.ts
@@ -14,13 +14,11 @@ interface Literal<T extends LiteralBase = LiteralBase> extends Runtype.Common<T>
 }
 
 const literal = (value: unknown): string =>
-	Array.isArray(value)
-		? globalThis.String(value.map(literal))
-		: value !== null && typeof value === "object"
-			? "[object Object]"
-			: typeof value === "bigint"
-				? globalThis.String(value) + "n"
-				: globalThis.String(value)
+	value !== null && typeof value === "object"
+		? "[object Object]"
+		: typeof value === "bigint"
+			? globalThis.String(value) + "n"
+			: globalThis.String(value)
 
 /**
  * Construct a runtype for a type literal.


### PR DESCRIPTION
Works around the following issue:

```typescript
String(Object.create(null))
// Uncaught TypeError: Cannot convert object to primitive value

Literal(1).validate(Object.create(null))
// Uncaught TypeError: Cannot convert object to primitive value
```

We encountered this issue when working with [Apollo Server](https://github.com/apollographql/apollo-server). It appears to create arguments with a null prototype 🤷.

I've cleaned up a comment regarding `Symbol()` stringification that does not apply to the `String()` constructor as per added test case and MDN.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/String#using_string_to_stringify_a_symbol