### PR TITLE
improvement!: make top-level `match` require `when`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,7 @@ export { default as AsyncContract } from "./utils/AsyncContract.ts"
 export { default as BigInt } from "./BigInt.ts"
 export { default as Boolean } from "./Boolean.ts"
 export { default as Brand, type RuntypeBrand } from "./Brand.ts"
-export {
-	type Case,
-	type Match,
-	type Matcher,
-	type PairCase,
-	default as match,
-	when,
-} from "./utils/match.ts"
+export { type Case, type Match, type Matcher, default as match, when } from "./utils/match.ts"
 export { default as Constraint } from "./Constraint.ts"
 export { default as Contract } from "./utils/Contract.ts"
 export { type default as Failure } from "./result/Failure.ts"

--- a/src/utils/match.test.ts
+++ b/src/utils/match.test.ts
@@ -6,10 +6,10 @@ import { assert, assertThrows } from "@std/assert"
 
 Deno.test("match", async t => {
 	await t.step("works", async t => {
-		const f: (value: string | number) => number = match(
-			when(Literal(42), fortyTwo => fortyTwo / 2),
-			when(Number, n => n + 9),
-			when(String, s => s.length * 2),
+		const f = match(
+			when([Literal(42), fortyTwo => fortyTwo / 2]),
+			when([Number, n => n + 9]),
+			when([String, s => s.length * 2]),
 		)
 
 		assert(f(42) === 21)


### PR DESCRIPTION
Without using `when`, the parameter of case body would be `any` so it may compile wrong code silently, thus it's reasonable for top-level `match` to always require use of `when`.